### PR TITLE
Feature#32/finish references

### DIFF
--- a/reloj-checador/Gemfile.lock
+++ b/reloj-checador/Gemfile.lock
@@ -66,9 +66,6 @@ GEM
     bindex (0.8.1)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
-    bootstrap_form (4.5.0)
-      actionpack (>= 5.2)
-      activemodel (>= 5.2)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.35.3)
@@ -278,7 +275,6 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)
-  bootstrap_form (~> 4.0)
   byebug
   capybara (>= 3.26)
   database_cleaner-active_record

--- a/reloj-checador/app/models/company.rb
+++ b/reloj-checador/app/models/company.rb
@@ -1,3 +1,4 @@
 class Company < ApplicationRecord
   validates :name, :address, presence: true
+  belongs_to :user
 end

--- a/reloj-checador/app/models/employee_attendance.rb
+++ b/reloj-checador/app/models/employee_attendance.rb
@@ -1,3 +1,5 @@
 class EmployeeAttendance < ApplicationRecord
   has_many :attendances
+  has_many :users
+  enum type: %i[check_in check_out]
 end

--- a/reloj-checador/app/models/user.rb
+++ b/reloj-checador/app/models/user.rb
@@ -3,7 +3,9 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
+  belongs_to :employee_attendance
+  has_many :companies
   enum status: %i[active inactive]
   enum role: %i[employee admin]
+  
 end

--- a/reloj-checador/db/migrate/20210702204526_create_employee_attendance.rb
+++ b/reloj-checador/db/migrate/20210702204526_create_employee_attendance.rb
@@ -1,7 +1,7 @@
 class CreateEmployeeAttendance < ActiveRecord::Migration[6.1]
   def change
     create_table :employee_attendance do |t|
-      t.integer :type
+      t.integer :type, default: 1
 
       t.timestamps
     end

--- a/reloj-checador/db/migrate/20210706155956_add_user_ref_to_employee_attendance.rb
+++ b/reloj-checador/db/migrate/20210706155956_add_user_ref_to_employee_attendance.rb
@@ -1,0 +1,5 @@
+class AddUserRefToEmployeeAttendance < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :employee_attendance, :user, null: false, foreign_key: true
+  end
+end

--- a/reloj-checador/db/migrate/20210706160048_add_company_ref_to_users.rb
+++ b/reloj-checador/db/migrate/20210706160048_add_company_ref_to_users.rb
@@ -1,0 +1,5 @@
+class AddCompanyRefToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :users, :company, null: false, foreign_key: true
+  end
+end

--- a/reloj-checador/db/schema.rb
+++ b/reloj-checador/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2021_07_04_035504) do
+ActiveRecord::Schema.define(version: 2021_07_06_160048) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,10 +32,9 @@ ActiveRecord::Schema.define(version: 2021_07_04_035504) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "attendance_id", null: false
+    t.bigint "user_id", null: false
     t.index ["attendance_id"], name: "index_employee_attendance_on_attendance_id"
-  end
-
-  add_foreign_key "employee_attendance", "attendances"
+    t.index ["user_id"], name: "index_employee_attendance_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -51,9 +49,15 @@ ActiveRecord::Schema.define(version: 2021_07_04_035504) do
     t.string "position"
     t.string "employee_number"
     t.string "private_number"
-    t.integer "status"
-    t.integer "role"
+    t.integer "status", default: 0
+    t.integer "role", default: 1
+    t.bigint "company_id", null: false
+    t.index ["company_id"], name: "index_users_on_company_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "employee_attendance", "attendances"
+  add_foreign_key "employee_attendance", "users"
+  add_foreign_key "users", "companies"
 end


### PR DESCRIPTION
# Description
 - I added the model references.
 - This was done in order to be able to fully relate the database and start coding CRUDs.

- I modified the type field and added an Enum.
- This was to be able to check out and check in the employee.

- I ran the new migrations with the new references.